### PR TITLE
fix: use spawn's shell option to follow npm and fix batch script shells

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,20 +241,6 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
     conf.windowsVerbatimArguments = true
   }
 
-  // Spawning .bat and .cmd files on Windows requires the "shell" option to
-  // spawn to be set. Otherwise spawn will throw with EINVAL.
-  //
-  // https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
-  // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-  //
-  // The shell option is security sensitive. It should make sense for this
-  // usecase since scripts in package.json intentionally run on the shell.
-  // Avoiding setting the shell option in all cases to preserve existing
-  // behavior on non-Windows platforms.
-  if (process.platform === 'win32' && customShell && (customShell.endsWith('.bat') || customShell.endsWith('.cmd'))) {
-    conf.shell = true
-  }
-
   opts.log.verbose('lifecycle', logid(pkg, stage), 'PATH:', env[PATH])
   opts.log.verbose('lifecycle', logid(pkg, stage), 'CWD:', wd)
   opts.log.silly('lifecycle', logid(pkg, stage), 'Args:', [shFlag, cmd])


### PR DESCRIPTION
## Problem

A PR earlier today (https://github.com/pnpm/npm-lifecycle/pull/42) attempted to fix `spawn EINVAL` errors on Windows, but accidentally changed how arguments were passed to the custom shell. Thankfully a test in the pnpm repo caught this and failed.

```
● pnpm run with custom shell

    expect(received).toStrictEqual(expected) // deep equality
 
    - Expected  - 1
    + Received  + 2
 
      Array [
        "-c",
    -   "foo bar",
    +   "foo",
    +   "bar",
      ]
```

## Changes

Instead of option 3, let's go with option 2.

> I thought through a few options on how to fix this:
>
> 1. Re-fork the `@npm/run-script` package and use that in pnpm.
> 2. Match how `@npm/run-script` uses `spawn` and pass `{ shell: scriptShell }` as an option.
> 3. Set `{ shell: true }` on Windows when `scriptShell` is a batch file.

## Testing

I used `pnpm patch` to edit `@pnpm/npm-lifecycle` to trigger a CI job in the pnpm repo. Running on my fork to make sure the fix above works.

https://github.com/gluxon/pnpm/actions/runs/8692862152