### PR TITLE
fix: `cd` builtin is not working on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ exports.makeEnv = makeEnv
 
 const spawn = require('./lib/spawn')
 const { execute } = require('@yarnpkg/shell')
+const { npath } = require('@yarnpkg/fslib')
 const path = require('path')
 const Stream = require('stream').Stream
 const fs = require('fs')
@@ -246,7 +247,7 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   opts.log.silly('lifecycle', logid(pkg, stage), 'Args:', [shFlag, cmd])
 
   if (opts.shellEmulator) {
-    const execOpts = { cwd: wd, env }
+    const execOpts = { cwd: npath.toPortablePath(wd), env }
     if (opts.stdio === 'pipe') {
       const stdout = new PassThrough()
       const stderr = new PassThrough()

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/byline": "^1.0.0",
     "@pnpm/error": "^1000.0.2",
+    "@yarnpkg/fslib": "^3.0.0",
     "@yarnpkg/shell": "4.0.0",
     "node-gyp": "^11.1.0",
     "resolve-from": "^5.0.0",


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->

This PR is trying to fix pnpm/pnpm#7838 by changing cwd passed to `@yarnpkg/shell` to portable path.

https://github.com/yarnpkg/berry/blob/182046546379f3b4e111c374946b32d92be5d933/packages/yarnpkg-shell/sources/commands/entry.ts#L54