### PR TITLE
Exit with 130 after receiving SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,7 +330,7 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
     proc.kill()
   }
   function procInterrupt () {
-    proc.on('close', () => process.exit(130))
+    proc.on('exit', () => process.exit(130))
     proc.kill('SIGINT')
     process.once('SIGINT', procKill)
   }

--- a/index.js
+++ b/index.js
@@ -318,8 +318,9 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
       er.pkgname = pkg.name
     }
     process.removeListener('SIGTERM', procKill)
-    process.removeListener('SIGTERM', procInterrupt)
     process.removeListener('SIGINT', procKill)
+    process.removeListener('SIGINT', procInterrupt)
+    process.removeListener('exit', procKill)
     return cb(er)
   }
   let called = false
@@ -329,10 +330,8 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
     proc.kill()
   }
   function procInterrupt () {
+    proc.on('close', () => process.exit(130))
     proc.kill('SIGINT')
-    proc.on('exit', () => {
-      process.exit()
-    })
     process.once('SIGINT', procKill)
   }
 }

--- a/test/fixtures/count-to-10/package.json
+++ b/test/fixtures/count-to-10/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "postinstall": "node postinstall",
-    "signal-abrt": "echo 'signal-exit script' && kill -s ABRT $$",
+    "signal-abrt": "echo 'signal-abrt script' && kill -s ABRT $$",
     "signal-int": "echo 'signal-int script' && kill -s INT $$"
   }
 }

--- a/test/fixtures/sleep/package.json
+++ b/test/fixtures/sleep/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sleep",
+  "version": "1.0.0",
+  "//": [
+    "Notes about the sleep-notify script below:",
+    "1)  The complexity of the script is necessary because we're signalling",
+    "    sh only, rather than what Posix shells do on Ctrl-C, which is to",
+    "    send SIGINT to the entire foreground process group.",
+    "2)  We trap SIGINT and exit with a code rather. This avoids the",
+    "    special handling of SIGINT exits which are treated as a success.",
+    "3)  The trap also seems to be necessary to make sh exit promptly.",
+    "4)  We don't want the parent process to send SIGINT to child before it",
+    "    has full started, so we send a signal to parent to coordinate the test."
+  ],
+  "scripts": {
+    "sleep-notify": "trap 'exit 130' SIGINT; kill -USR1 $PPID; for i in {1..100}; do sleep .01; done"
+  }
+}


### PR DESCRIPTION
pnpm should exit with non-zero code when aborting
abnormally due to SIGINT

Fixes: pnpm/pnpm#9626
