### PR TITLE
Misc signal cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,8 +318,9 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
       er.pkgname = pkg.name
     }
     process.removeListener('SIGTERM', procKill)
-    process.removeListener('SIGTERM', procInterrupt)
     process.removeListener('SIGINT', procKill)
+    process.removeListener('SIGINT', procInterrupt)
+    process.removeListener('exit', procKill)
     return cb(er)
   }
   let called = false
@@ -330,9 +331,6 @@ function runCmd_ (cmd, pkg, env, wd, opts, stage, unsafe, uid, gid, cb_) {
   }
   function procInterrupt () {
     proc.kill('SIGINT')
-    proc.on('exit', () => {
-      process.exit()
-    })
     process.once('SIGINT', procKill)
   }
 }

--- a/test/fixtures/count-to-10/package.json
+++ b/test/fixtures/count-to-10/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "postinstall": "node postinstall",
-    "signal-abrt": "echo 'signal-exit script' && kill -s ABRT $$",
+    "signal-abrt": "echo 'signal-abrt script' && kill -s ABRT $$",
     "signal-int": "echo 'signal-int script' && kill -s INT $$"
   }
 }


### PR DESCRIPTION
- Fix test msg
- Remove proc 'exit' handler during interrupt
  This code was a no-op as spawn.js does not emit `exit` events.
  This is actually good, because  were it to be working, it would
  result in a race condition when a child exits non-zero:
  1. The lifecycle promise would be rejected, leading to log output
     and a possible pnpm exit
  2. This hook would force node to exit 0 immediately.

- Fix the listener removals when child exits.
