### PR TITLE
fix: modify the value of the environment variable TMPDIR

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,9 +100,9 @@ function lifecycle (pkg, stage, wd, opts) {
         // 'nobody' typically doesn't have permission to write to /tmp
         // even if it's never used, sh freaks out.
         if (!opts.unsafePerm) {
-          const tmpdir = path.join(wd, 'node_modules')
+          const tmpdir = path.join(wd, 'node_modules', '.tmp')
           try {
-            fs.mkdirSync(tmpdir)
+            fs.mkdirSync(tmpdir, { recursive: true })
           } catch (err) {
             if (err.code !== 'EEXIST') throw err
           }

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function lifecycle (pkg, stage, wd, opts) {
 
         // 'nobody' typically doesn't have permission to write to /tmp
         // even if it's never used, sh freaks out.
-        if (!opts.unsafePerm) env.TMPDIR = wd
+        if (!opts.unsafePerm) env.TMPDIR = path.join(wd, 'node_modules')
 
         lifecycle_(pkg, stage, wd, opts, env, (er) => {
           if (er) return reject(er)

--- a/index.js
+++ b/index.js
@@ -99,7 +99,11 @@ function lifecycle (pkg, stage, wd, opts) {
 
         // 'nobody' typically doesn't have permission to write to /tmp
         // even if it's never used, sh freaks out.
-        if (!opts.unsafePerm) env.TMPDIR = path.join(wd, 'node_modules')
+        if (!opts.unsafePerm) {
+          const tmpdir = path.join(wd, 'node_modules')
+          if (!fs.existsSync(tmpdir)) fs.mkdirSync(tmpdir)
+          env.TMPDIR = tmpdir
+        }
 
         lifecycle_(pkg, stage, wd, opts, env, (er) => {
           if (er) return reject(er)

--- a/index.js
+++ b/index.js
@@ -101,7 +101,11 @@ function lifecycle (pkg, stage, wd, opts) {
         // even if it's never used, sh freaks out.
         if (!opts.unsafePerm) {
           const tmpdir = path.join(wd, 'node_modules')
-          if (!fs.existsSync(tmpdir)) fs.mkdirSync(tmpdir)
+          try {
+            fs.mkdirSync(tmpdir)
+          } catch (err) {
+            if (err.code !== 'EEXIST') throw err
+          }
           env.TMPDIR = tmpdir
         }
 


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
When executing the script through the `postinstall` hook in a Linux environment, the value of `opts.unsafePerm` passed in is `false`, so the value of the environment variable `TMPDIR` is set to the current directory, causing `os.tmpdir()` to return a directory other than the temporary directory.

fix https://github.com/pnpm/pnpm/issues/9718