### PR TITLE
fix: remove duplicate entries in PATH

### DIFF
--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -33,6 +33,14 @@ function spawn (cmd, args, options, log) {
   const cmdWillOutput = willCmdOutput(options && options.stdio)
 
   if (cmdWillOutput) startRunning(log)
+
+  if (options.env["PATH"]) {
+    const fullPath = options.env["PATH"]
+    const parts = fullPath.split(":")
+    const partsDedup = new Set(parts)
+    options.env["PATH"] = [...partsDedup].join(":")
+  }
+
   const raw = _spawn(cmd, args, options)
   const cooked = new EventEmitter()
 


### PR DESCRIPTION
Otherwise the environment variable may be longer than 128KiB, which Linux does not allow (spawn fails with E2BIG).
There are various bug reports related to E2BIG failures:
https://github.com/pnpm/pnpm/issues/6106
https://github.com/pnpm/pnpm/issues/8552

I'm not sure how to handle project paths that contain a colon `:`.
And I'm not sure whether this would be the "best" fix, because it would certainly be better to address the issue at the root cause (somewhere else in pnpm the PATH variable is generated with duplicate entries).